### PR TITLE
Allow custom window functions for STFT and ISTFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ noise to a raw audio waveform.
 import dm_aux as aux
 import jax
 
-# Load an waveform into a NumPy array with your preferred library.
+# Load a waveform into a NumPy array with your preferred library.
 x = load_waveform()
 
 key = jax.random.PRNGKey(0)

--- a/dm_aux/spectral.py
+++ b/dm_aux/spectral.py
@@ -230,8 +230,8 @@ def istft(stft_matrix: chex.Array,
   signal = jnp.squeeze(signal, axis=-1)
 
   ifft_window_sum = librosa.filters.window_sumsquare(
-      window_fn,
-      num_frames,
+      window=window_fn,
+      n_frames=num_frames,
       win_length=frame_length,
       n_fft=n_fft,
       hop_length=frame_step,

--- a/dm_aux/spectral.py
+++ b/dm_aux/spectral.py
@@ -14,7 +14,7 @@
 """Audio spectral transformations."""
 
 import enum
-from typing import Optional, Union, Tuple
+from typing import Callable, Optional, Union, Tuple
 
 import chex
 import jax
@@ -38,7 +38,8 @@ def stft(signal: chex.Array,
          n_fft: int = 2048,
          frame_length: Optional[int] = None,
          frame_step: Optional[int] = None,
-         window_fn: Optional[Union[str, float, Tuple[str, float]]] = 'hann',
+         window_fn: Optional[Union[str, float, Tuple[str, float], Callable[[int], Union[jnp.ndarray, np.ndarray]],
+           Union[jnp.ndarray, np.ndarray]]] = 'hann',
          pad: Pad = Pad.END,
          pad_mode: str = 'constant',
          precision: Optional[jax.lax.Precision] = None,
@@ -70,8 +71,8 @@ def stft(signal: chex.Array,
       of the frame introduced by segmentation. If it is a str, it is passed to
       `scipy.signal.get_window` - see the oringal Scipy doc for more details
       (docs.scipy.org/doc/scipy-1.7.1/reference/generated/scipy.signal
-       .get_window.html). If not a str, it must be a callable that accepts a
-       frame length, or a jax.numpy array.
+       .get_window.html). If not a str, it must be a jax.numpy array, numpy array
+       or a callable that accepts a frame length argument.
     pad: pad the signal at the end(s) by `int(n_fft // 2)`. Can either be
       `Pad.NONE`, `Pad.START`, `Pad.END`, `Pad.BOTH`, `Pad.ALIGNED`.
     pad_mode: the mode of padding of the signal when `pad` is not None. It is a
@@ -101,9 +102,9 @@ def stft(signal: chex.Array,
 
   # Get the window function.
   if callable(window_fn):
-    fft_window = window_fn(frame_length)
-  elif isinstance(window_fn, jnp.ndarray):
-    fft_window = window_fn
+    fft_window = np.array(window_fn(frame_length))
+  elif isinstance(window_fn, (np.ndarray, jnp.ndarray)):
+    fft_window = np.array(window_fn)
   else:
     fft_window = sp_signal.get_window(window_fn, frame_length, fftbins=True)
   # Pad the window to length n_fft with zeros.
@@ -154,7 +155,8 @@ def stft(signal: chex.Array,
 def istft(stft_matrix: chex.Array,
           frame_length: Optional[int] = None,
           frame_step: Optional[int] = None,
-          window_fn: Optional[Union[str, float, Tuple[str, float]]] = 'hann',
+          window_fn: Optional[Union[str, float, Tuple[str, float], Callable[[int], Union[jnp.ndarray, np.ndarray]],
+            Union[jnp.ndarray, np.ndarray]]] = 'hann',
           pad: Pad = Pad.END,
           length: Optional[int] = None,
           precision: Optional[jax.lax.Precision] = None) -> chex.Array:
@@ -174,10 +176,11 @@ def istft(stft_matrix: chex.Array,
     frame_step: the hop size of extracting signal frames. If unspecified it
       defaults to be equal to `int(frame_length // 2)`.
     window_fn: applied to each frame to remove the discontinuities at the edge
-      of the frame introduced by segmentation. It is passed to
+      of the frame introduced by segmentation. If it is a str, it is passed to
       `scipy.signal.get_window` - see the oringal Scipy doc for more details
       (docs.scipy.org/doc/scipy-1.7.1/reference/generated/scipy.signal
-       .get_window.html).
+       .get_window.html). If not a str, it must be a jax.numpy array, numpy array
+       or a callable that accepts a frame length argument.
     pad: pad the signal at the end(s) by `int(n_fft // 2)`. Can either be
       `Pad.NONE`, `Pad.START`, `Pad.END`, `Pad.BOTH`, `Pad.ALIGNED`.
     length: the trim length of the time domain signal to output.
@@ -200,7 +203,12 @@ def istft(stft_matrix: chex.Array,
     frame_step = int(frame_length // 2)
 
   # Get the window function.
-  ifft_window = scipy.signal.get_window(window_fn, frame_length, fftbins=True)
+  if callable(window_fn):
+    ifft_window = window_fn = np.array(window_fn(frame_length))
+  elif isinstance(window_fn, (np.ndarray, jnp.ndarray)):
+    ifft_window = window_fn = np.array(window_fn)
+  else:
+    ifft_window = sp_signal.get_window(window_fn, frame_length, fftbins=True)
   # Pad the window to length n_fft with zeros.
   if frame_length < n_fft:
     left_pad = int((n_fft - frame_length) // 2)

--- a/dm_aux/spectral_test.py
+++ b/dm_aux/spectral_test.py
@@ -67,12 +67,12 @@ class SpectralTest(parameterized.TestCase):
     stft_matrix = spectral.stft(
         signal=data, n_fft=n_fft, frame_length=win_length,
         frame_step=hop_length, window_fn=window, pad=Pad.BOTH,
-        precision=self._get_precision(), pad_mode='reflect')
+        precision=self._get_precision(), pad_mode='constant')
 
     spectral_stft = jax.jit(functools.partial(
         spectral.stft, n_fft=n_fft, frame_length=win_length,
         frame_step=hop_length, window_fn=window, pad=Pad.BOTH,
-        precision=self._get_precision(), pad_mode='reflect'))
+        precision=self._get_precision(), pad_mode='constant'))
     stft_matrix_jit = spectral_stft(signal=data)
 
     np.testing.assert_allclose(stft_matrix[0], stft_matrix_np, rtol=1e-3,
@@ -192,7 +192,7 @@ class SpectralTest(parameterized.TestCase):
     stft_matrix = spectral.stft(
         signal=data, n_fft=n_fft, frame_length=win_length,
         frame_step=hop_length, window_fn=window, pad=Pad.BOTH,
-        precision=self._get_precision(), pad_mode='reflect')
+        precision=self._get_precision(), pad_mode='constant')
 
     # Librosa iSTFT
     reconst_data_np = librosa.core.istft(
@@ -231,7 +231,7 @@ class SpectralTest(parameterized.TestCase):
     stft_matrix = spectral.stft(
         signal=data, n_fft=n_fft, frame_length=win_length,
         frame_step=hop_length, window_fn=window, pad=pad,
-        precision=self._get_precision(), pad_mode='reflect')
+        precision=self._get_precision(), pad_mode='constant')
 
     reconst_data = spectral.istft(
         stft_matrix=stft_matrix, frame_length=win_length, frame_step=hop_length,

--- a/dm_aux/spectral_test.py
+++ b/dm_aux/spectral_test.py
@@ -49,6 +49,10 @@ class SpectralTest(parameterized.TestCase):
            n_fft=320, hop_length=160, win_length=160, window='hann'),
       dict(testcase_name='longer_input', data_length=8000, n_fft=320,
            hop_length=160, win_length=320, window='hann'),
+      dict(testcase_name='custom_window_array', data_length=4000, n_fft=320,
+           hop_length=160, win_length=320, window=scipy.signal.get_window('hann', 320)),
+      dict(testcase_name='custom_window_fn', data_length=4000, n_fft=320,
+           hop_length=160, win_length=320, window=functools.partial(scipy.signal.get_window, 'hann')),
       )
   def test_stft_matches_librosa(self, data_length, n_fft, hop_length,
                                 win_length, window):
@@ -181,6 +185,10 @@ class SpectralTest(parameterized.TestCase):
            hop_length=160, win_length=320, window='hamming'),
       dict(testcase_name='shorter_input', data_length=4000, n_fft=320,
            hop_length=160, win_length=320, window='hann'),
+      dict(testcase_name='custom_window_array', data_length=8000, n_fft=320,
+           hop_length=160, win_length=320, window=scipy.signal.get_window('hann', 320)),
+      dict(testcase_name='custom_window_fn', data_length=8000, n_fft=320,
+           hop_length=160, win_length=320, window=functools.partial(scipy.signal.get_window, 'hann')),
       )
   def test_istft_matches_librosa(self, data_length, n_fft, hop_length,
                                  win_length, window):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
 chex>=0.0.6
-numpy<1.22
-librosa==0.8.1
-# jax>=0.2.17
-# jaxlib>=0.1.69
+numpy<1.27
+librosa==0.10.1
+# jax>=0.4.24
+# jaxlib>=0.4.24


### PR DESCRIPTION
For istft and stft, the window_fn argument can now be a callable or a numpy/jax.numpy array. I added tests too.

Motivation: I wanted to be able to do a square-root Hann window like [AudioTools can do](https://github.com/descriptinc/audiotools/blob/7776c296c711db90176a63ff808c26e0ee087263/audiotools/core/audio_signal.py#L1035).